### PR TITLE
Clippy and refactor 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
 
   library_checker_aizu_tests:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -41,6 +39,4 @@ jobs:
         rustup override set nightly
         rustup component add --toolchain nightly rustfmt clippy
     - name: use oj-verify
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: oj-verify all --tle 2 --jobs 4 --timeout 3600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     - name: cargo fmt
       run: cargo fmt --all -- --check
 
-        #- name: cargo clippy
-      # `-D warnings` will fail CI on any warning
-      #run: cargo clippy --all-targets --all-features -- -D warnings
+    - name: cargo clippy
+      #`-D warnings` causes CI to fail on any warning
+      run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: cargo test
       run: RUSTFLAGS="-D warnings" cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: cargo test
+      # RUSTFLAGS="-D warnings" will fail CI on any compile warning
       run: RUSTFLAGS="-D warnings" cargo test
 
     - name: use oj-verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       #run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: cargo test
-      run: cargo test -- -D warnings
+      run: RUSTFLAGS="-D warnings" cargo test
 
     - name: install oj-verify
       run: pip3 install -U online-judge-verify-helper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: cargo clippy
+      # `-D warnings` will fail CI on any warning
       run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: cargo test
-      # RUSTFLAGS="-D warnings" will fail CI on any compile warning
-      run: RUSTFLAGS="-D warnings" cargo test
+      run: cargo test -- -D warnings
 
     - name: use oj-verify
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
     - name: use oj-verify
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: oj-verify all --tle 1 --jobs 4 --timeout 3600
+      run: oj-verify all --tle 2 --jobs 4 --timeout 3600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     - name: cargo fmt
       run: cargo fmt --all -- --check
 
-    - name: cargo clippy
+        #- name: cargo clippy
       # `-D warnings` will fail CI on any warning
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      #run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: cargo test
       run: cargo test -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
     - uses: actions/setup-python@v4
     - name: install oj-verify
       run: pip3 install -U online-judge-verify-helper
+    - name: Set up Rust (nightly)
+      run: |
+        rustup install nightly
+        rustup override set nightly
+        rustup component add --toolchain nightly rustfmt clippy
     - name: use oj-verify
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,13 @@ jobs:
       run: |
         rustup install nightly
         rustup override set nightly
-        rustup component add --toolchain nightly rustfmt
+        rustup component add --toolchain nightly rustfmt clippy
 
     - name: cargo fmt
       run: cargo fmt --all -- --check
+
+    - name: cargo clippy
+      run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: cargo test
       # RUSTFLAGS="-D warnings" will fail CI on any compile warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,18 @@ jobs:
         rustup override set nightly
         rustup component add --toolchain nightly rustfmt clippy
     - name: use oj-verify
-      run: oj-verify all --tle 2 --jobs 4 --timeout 3600
+      # regarging `--tle 2`: the oj-verify tool only allows testing in release mode
+      #
+      # regarding `--jobs 4`: github CI runs with 4 cores
+      # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+      #
+      # regarding `--timeout `: github CI limits jobs to 6 hours
+      # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
+      #
+      # since the library is a single crate, on a commit the entire crate is
+      # rebuild, so oj-verify tool thinks everything changed, and then reruns all
+      # tests; thus another reason for setting long timeout.
+      #
+      # since all tests are rerun on every commit anyways, there's no need for
+      # the .verify-helper/timestamps.remote.json file
+      run: oj-verify all --tle 2 --jobs 4 --timeout 21600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
 
     - uses: actions/setup-python@v4
 
-    - name: install oj-verify
-      run: pip3 install -U online-judge-verify-helper
-
     - name: Set up Rust (nightly)
       run: |
         rustup install nightly
@@ -31,6 +28,9 @@ jobs:
 
     - name: cargo test
       run: cargo test -- -D warnings
+
+    - name: install oj-verify
+      run: pip3 install -U online-judge-verify-helper
 
     - name: use oj-verify
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       run: cargo fmt --all -- --check
     - name: cargo clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
-    - name: cargo test
-      run: cargo test --verbose
+    - name: cargo build
+      run: cargo build --verbose
 
   library_checker_aizu_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
 
     - uses: actions/setup-python@v4
 
+    - name: install oj-verify
+      run: pip3 install -U online-judge-verify-helper
+
     - name: Set up Rust (nightly)
       run: |
         rustup install nightly
@@ -28,9 +31,6 @@ jobs:
 
     - name: cargo test
       run: RUSTFLAGS="-D warnings" cargo test
-
-    - name: install oj-verify
-      run: pip3 install -U online-judge-verify-helper
 
     - name: use oj-verify
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,38 +2,40 @@ name: CI
 
 on: [push, workflow_dispatch]
 
-jobs:
-  verify:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
+env:
+  CARGO_TERM_COLOR: always
+  # causes CI to fail on any warning
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
 
+jobs:
+  cargo:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-
     - uses: actions/setup-python@v4
-
-    - name: install oj-verify
-      run: pip3 install -U online-judge-verify-helper
-
     - name: Set up Rust (nightly)
       run: |
         rustup install nightly
         rustup override set nightly
         rustup component add --toolchain nightly rustfmt clippy
-
     - name: cargo fmt
       run: cargo fmt --all -- --check
-
     - name: cargo clippy
-      #`-D warnings` causes CI to fail on any warning
       run: cargo clippy --all-targets --all-features -- -D warnings
-
     - name: cargo test
-      # RUSTFLAGS="-D warnings" will fail CI on any compile warning
-      run: RUSTFLAGS="-D warnings" cargo test
+      run: cargo test --verbose
 
+  library_checker_aizu_tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - name: install oj-verify
+      run: pip3 install -U online-judge-verify-helper
     - name: use oj-verify
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: oj-verify all --tle 1
+      run: oj-verify all --tle 1 --jobs 4 --timeout 3600

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.verify-helper/

--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,6 +1,6 @@
 {
-"examples/point_add_range_sum.rs": "2024-05-16 10:55:33 -0600",
-"examples/shortest_path.rs": "2024-05-16 10:55:33 -0600",
-"examples/staticrmq.rs": "2024-05-16 10:55:33 -0600",
-"examples/unionfind.rs": "2024-05-16 10:55:33 -0600"
+"examples/point_add_range_sum.rs": "2024-05-16 18:00:52 -0600",
+"examples/shortest_path.rs": "2024-05-16 18:00:52 -0600",
+"examples/staticrmq.rs": "2024-05-16 18:00:52 -0600",
+"examples/unionfind.rs": "2024-05-16 18:00:52 -0600"
 }

--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,5 +1,6 @@
 {
-"examples/point_add_range_sum.rs": "2024-05-16 18:20:29 -0600",
-"examples/shortest_path.rs": "2024-05-16 18:20:29 -0600",
-"examples/unionfind.rs": "2024-05-16 18:20:29 -0600"
+"examples/point_add_range_sum.rs": "2024-05-16 18:24:05 -0600",
+"examples/shortest_path.rs": "2024-05-16 18:24:05 -0600",
+"examples/staticrmq.rs": "2024-05-16 18:24:05 -0600",
+"examples/unionfind.rs": "2024-05-16 18:24:05 -0600"
 }

--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,6 +1,6 @@
 {
-"examples/point_add_range_sum.rs": "2024-05-16 07:12:14 -0600",
-"examples/shortest_path.rs": "2024-05-16 07:12:14 -0600",
-"examples/staticrmq.rs": "2024-05-16 07:12:14 -0600",
-"examples/unionfind.rs": "2024-05-16 07:12:14 -0600"
+"examples/point_add_range_sum.rs": "2024-05-16 08:51:17 -0600",
+"examples/shortest_path.rs": "2024-05-16 08:51:17 -0600",
+"examples/staticrmq.rs": "2024-05-16 08:51:17 -0600",
+"examples/unionfind.rs": "2024-05-16 08:51:17 -0600"
 }

--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,6 +1,5 @@
 {
-"examples/point_add_range_sum.rs": "2024-05-16 18:00:52 -0600",
-"examples/shortest_path.rs": "2024-05-16 18:00:52 -0600",
-"examples/staticrmq.rs": "2024-05-16 18:00:52 -0600",
-"examples/unionfind.rs": "2024-05-16 18:00:52 -0600"
+"examples/point_add_range_sum.rs": "2024-05-16 18:20:29 -0600",
+"examples/shortest_path.rs": "2024-05-16 18:20:29 -0600",
+"examples/unionfind.rs": "2024-05-16 18:20:29 -0600"
 }

--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,6 +1,6 @@
 {
-"examples/point_add_range_sum.rs": "2024-05-16 08:51:17 -0600",
-"examples/shortest_path.rs": "2024-05-16 08:51:17 -0600",
-"examples/staticrmq.rs": "2024-05-16 08:51:17 -0600",
-"examples/unionfind.rs": "2024-05-16 08:51:17 -0600"
+"examples/point_add_range_sum.rs": "2024-05-16 10:55:33 -0600",
+"examples/shortest_path.rs": "2024-05-16 10:55:33 -0600",
+"examples/staticrmq.rs": "2024-05-16 10:55:33 -0600",
+"examples/unionfind.rs": "2024-05-16 10:55:33 -0600"
 }

--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,6 +1,0 @@
-{
-"examples/point_add_range_sum.rs": "2024-05-16 18:24:05 -0600",
-"examples/shortest_path.rs": "2024-05-16 18:24:05 -0600",
-"examples/staticrmq.rs": "2024-05-16 18:24:05 -0600",
-"examples/unionfind.rs": "2024-05-16 18:24:05 -0600"
-}

--- a/examples/point_add_range_sum.rs
+++ b/examples/point_add_range_sum.rs
@@ -12,8 +12,8 @@ fn main() {
     }
 
     let mut fenwick = Fenwick::<u64>::new(n);
-    for (i, elem) in a.iter().enumerate() {
-        fenwick.add(i, *elem as u64);
+    for (i, &elem) in a.iter().enumerate() {
+        fenwick.add(i, elem as u64);
     }
 
     for que in queries {

--- a/examples/point_add_range_sum.rs
+++ b/examples/point_add_range_sum.rs
@@ -12,8 +12,8 @@ fn main() {
     }
 
     let mut fenwick = Fenwick::<u64>::new(n);
-    for i in 0..n {
-        fenwick.add(i, a[i] as u64);
+    for (i, elem) in a.iter().enumerate() {
+        fenwick.add(i, *elem as u64);
     }
 
     for que in queries {

--- a/src/dijk.rs
+++ b/src/dijk.rs
@@ -1,9 +1,9 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 
-pub fn dijk(adj: &Vec<Vec<(usize, u64)>>, s: usize) -> Vec<u64> {
+pub fn dijk(adj: &[Vec<(usize, u64)>], s: usize) -> Vec<u64> {
     let n = adj.len();
-    let mut dist = vec![std::u64::MAX; n];
+    let mut dist = vec![u64::MAX; n];
     let mut q = BinaryHeap::new();
     q.push(Reverse((0, s)));
     while let Some(Reverse((d, u))) = q.pop() {

--- a/src/dijk.rs
+++ b/src/dijk.rs
@@ -3,7 +3,6 @@ use std::collections::BinaryHeap;
 
 pub fn dijk(adj: &[Vec<(usize, u64)>], s: usize) -> Vec<u64> {
     let n = adj.len();
-    let unused = 0;
     let mut dist = vec![u64::MAX; n];
     let mut q = BinaryHeap::new();
     q.push(Reverse((0, s)));

--- a/src/dijk.rs
+++ b/src/dijk.rs
@@ -3,6 +3,7 @@ use std::collections::BinaryHeap;
 
 pub fn dijk(adj: &[Vec<(usize, u64)>], s: usize) -> Vec<u64> {
     let n = adj.len();
+    let unused = 0;
     let mut dist = vec![u64::MAX; n];
     let mut q = BinaryHeap::new();
     q.push(Reverse((0, s)));

--- a/src/rmq.rs
+++ b/src/rmq.rs
@@ -18,6 +18,7 @@ impl<T: Copy> RMQ<T> {
     }
 
     pub fn query(&self, range: std::ops::Range<usize>) -> T {
+        let unused = 0;
         let lg = range.len().ilog2() as usize;
         (self.op)(self.t[lg][range.start], self.t[lg][range.end - (1 << lg)])
     }

--- a/src/rmq.rs
+++ b/src/rmq.rs
@@ -3,8 +3,8 @@ pub struct RMQ<T> {
     op: fn(T, T) -> T,
 }
 impl<T: Copy> RMQ<T> {
-    pub fn new(a: &Vec<T>, op: fn(T, T) -> T) -> Self {
-        let mut t = vec![a.clone(); 1];
+    pub fn new(a: &[T], op: fn(T, T) -> T) -> Self {
+        let mut t = vec![a.to_owned(); 1];
         let mut i = 0;
         while (2 << i) <= a.len() {
             t.push(

--- a/src/rmq.rs
+++ b/src/rmq.rs
@@ -18,7 +18,6 @@ impl<T: Copy> RMQ<T> {
     }
 
     pub fn query(&self, range: std::ops::Range<usize>) -> T {
-        let unused = 0;
         let lg = range.len().ilog2() as usize;
         (self.op)(self.t[lg][range.start], self.t[lg][range.end - (1 << lg)])
     }


### PR DESCRIPTION
also install `oj-verify` tool later in CI (right before running lib checker tests) so we don't have to wait for it to install to see the results of all the cargo checks