### PR TITLE
consistency with partition_point

### DIFF
--- a/examples/graphs/hld_path_composite_yosupo.rs
+++ b/examples/graphs/hld_path_composite_yosupo.rs
@@ -70,11 +70,11 @@ fn main() {
                     x: usize
                 }
                 let (mut u_anc_val, mut v_anc_val) = (st_forwards.unit, st_backwards.unit);
-                hld.path(u, v, |range, v_anc| {
-                    if v_anc {
-                        v_anc_val = (st_forwards.op)(&st_forwards.query(range), &v_anc_val);
-                    } else {
+                hld.path(u, v, |range, u_anc| {
+                    if u_anc {
                         u_anc_val = (st_forwards.op)(&u_anc_val, &st_backwards.query(range));
+                    } else {
+                        v_anc_val = (st_forwards.op)(&st_forwards.query(range), &v_anc_val);
                     }
                 });
                 let res = (st_forwards.op)(&u_anc_val, &v_anc_val);

--- a/src/graphs/hld.rs
+++ b/src/graphs/hld.rs
@@ -86,21 +86,21 @@ impl HLD {
     /// - Time: O(log n) calls to `f`
     /// - Space: O(1)
     pub fn path(&self, mut u: usize, mut v: usize, mut f: impl FnMut(Range<usize>, bool)) {
-        let mut v_anc = true;
+        let mut u_anc = false;
         loop {
             if self.tin[u] > self.tin[v] {
                 std::mem::swap(&mut u, &mut v);
-                v_anc = !v_anc;
+                u_anc = !u_anc;
             }
             if self.head[u] == self.head[v] {
                 break;
             }
-            f(self.tin[self.head[v]]..self.tin[v] + 1, v_anc);
+            f(self.tin[self.head[v]]..self.tin[v] + 1, u_anc);
             v = self.p[self.head[v]].unwrap();
         }
         f(
             self.tin[u] + self.vals_edges as usize..self.tin[v] + 1,
-            v_anc,
+            u_anc,
         );
     }
 
@@ -187,7 +187,7 @@ impl HLD {
     pub fn kth_on_path(&self, u: usize, v: usize, k: usize) -> Option<usize> {
         let mut dst_side = [0; 2];
         self.path(u, v, |range, u_anc| dst_side[u_anc as usize] += range.len());
-        if k < dst_side[0] {
+        if k < dst_side[1] {
             return self.kth_par(u, k);
         }
         let dst = dst_side[0] + dst_side[1] - !self.vals_edges as usize;


### PR DESCRIPTION
https://doc.rust-lang.org/std/primitive.slice.html#method.partition_point

for the predicate you pass in: for some prefix of the array, the predicate is true, then for the remaining suffix, the predicate is false

Let's match this: for the path from u to LCA, the variable `which side` should be true, then for the path from v to LCA, it should be false