### PR TITLE
now RMQ op can access variables in outside scope

### DIFF
--- a/src/data_structures/rmq.rs
+++ b/src/data_structures/rmq.rs
@@ -5,22 +5,27 @@
 /// use programming_team_code_rust::data_structures::rmq::RMQ;
 ///
 /// let a = [1, 3, 2, 4, 5];
-/// let rmq = RMQ::new(&a, std::cmp::min);
-/// assert_eq!(rmq.query(0..5), 1);
-/// assert_eq!(rmq.query(1..4), 2);
+/// let rmq1 = RMQ::new(&a, std::cmp::min);
+/// assert_eq!(rmq1.query(0..5), 1);
+/// assert_eq!(rmq1.query(1..4), 2);
+///
+/// let outside_var = 5;
+/// let rmq2 = RMQ::new(&a, |x, y| if x + outside_var < y + outside_var { x } else { y });
+/// assert_eq!(rmq2.query(0..5), 1);
+/// assert_eq!(rmq2.query(1..4), 2);
 /// ```
-pub struct RMQ<T> {
+pub struct RMQ<T, F> {
     t: Vec<Vec<T>>,
-    op: fn(T, T) -> T,
+    op: F,
 }
 
-impl<T: Copy> RMQ<T> {
+impl<T: Copy, F: Fn(T, T) -> T> RMQ<T, F> {
     /// Create a new RMQ instance
     ///
     /// # Complexity (n = a.len())
     /// - Time: O(n log n)
     /// - Space: O(n log n)
-    pub fn new(a: &[T], op: fn(T, T) -> T) -> Self {
+    pub fn new(a: &[T], op: F) -> Self {
         let mut t = vec![a.to_owned(); 1];
         let mut i = 0;
         while (2 << i) <= a.len() {

--- a/src/graphs/lca.rs
+++ b/src/graphs/lca.rs
@@ -3,6 +3,8 @@
 use crate::data_structures::rmq::RMQ;
 use crate::graphs::dfs_order::get_dfs_preorder;
 
+type OpType = fn((usize, usize), (usize, usize)) -> (usize, usize);
+
 /// # Example
 /// ```
 /// use programming_team_code_rust::graphs::lca::LCA;
@@ -25,7 +27,7 @@ use crate::graphs::dfs_order::get_dfs_preorder;
 pub struct LCA {
     tin: Vec<usize>,
     p: Vec<usize>,
-    rmq: RMQ<(usize, usize), fn((usize, usize), (usize, usize)) -> (usize, usize)>,
+    rmq: RMQ<(usize, usize), OpType>,
 }
 
 impl LCA {
@@ -53,10 +55,7 @@ impl LCA {
             }
         }
         let d_with_order: Vec<(usize, usize)> = order.iter().map(|&u| (d[u], u)).collect();
-        let rmq = RMQ::<(usize, usize), fn((usize, usize), (usize, usize)) -> (usize, usize)>::new(
-            &d_with_order,
-            std::cmp::min,
-        );
+        let rmq = RMQ::<(usize, usize), OpType>::new(&d_with_order, std::cmp::min);
         LCA { tin, p, rmq }
     }
 

--- a/src/graphs/lca.rs
+++ b/src/graphs/lca.rs
@@ -25,7 +25,7 @@ use crate::graphs::dfs_order::get_dfs_preorder;
 pub struct LCA {
     tin: Vec<usize>,
     p: Vec<usize>,
-    rmq: RMQ<(usize, usize)>,
+    rmq: RMQ<(usize, usize), fn((usize, usize), (usize, usize)) -> (usize, usize)>,
 }
 
 impl LCA {
@@ -53,7 +53,10 @@ impl LCA {
             }
         }
         let d_with_order: Vec<(usize, usize)> = order.iter().map(|&u| (d[u], u)).collect();
-        let rmq = RMQ::new(&d_with_order, std::cmp::min);
+        let rmq = RMQ::<(usize, usize), fn((usize, usize), (usize, usize)) -> (usize, usize)>::new(
+            &d_with_order,
+            std::cmp::min,
+        );
         LCA { tin, p, rmq }
     }
 


### PR DESCRIPTION
So a `fn` type can't access anything in surrounding scope, but a closure can.

And `Fn` is the way to declare the signature of the closure

Using generic types (e.g. `F`) is a way to store a closure as a struct member