### PR TITLE
Dfs closure

### DIFF
--- a/src/graphs/dfs.rs
+++ b/src/graphs/dfs.rs
@@ -1,0 +1,24 @@
+fn dfs_impl<F, G>(u: usize, adj: &[Vec<usize>], seen: &mut [bool], pre: &mut F, post: &mut G)
+where
+    F: FnMut(usize),
+    G: FnMut(usize),
+{
+    pre(u);
+    seen[u] = true;
+    for &v in &adj[u] {
+        if !seen[v] {
+            dfs_impl(v, adj, seen, pre, post);
+        }
+    }
+    post(u);
+}
+
+pub fn dfs(adj: &[Vec<usize>], mut pre: impl FnMut(usize), mut post: impl FnMut(usize)) {
+    let n = adj.len();
+    let mut seen = vec![false; n];
+    for s in 0..n {
+        if !seen[s] {
+            dfs_impl(s, adj, &mut seen, &mut pre, &mut post);
+        }
+    }
+}

--- a/src/graphs/lca.rs
+++ b/src/graphs/lca.rs
@@ -1,7 +1,7 @@
 //! # Lowest Common Ancestor
 
 use crate::data_structures::rmq::RMQ;
-use crate::graphs::dfs_order::get_dfs_preorder;
+use crate::graphs::dfs::dfs;
 
 /// # Example
 /// ```
@@ -42,7 +42,19 @@ impl LCA {
         let mut tin = vec![0; n];
         let mut p = vec![0; n];
         let mut d = vec![0; n];
-        let order = get_dfs_preorder(adj);
+        let mut order = Vec::with_capacity(n);
+        dfs(adj, |u| {
+            tin[u] = order.len();
+            order.push(u);
+            for &v in &adj[u] {
+                if v != p[u] {
+                    p[v] = u;
+                    d[v] = d[u] + 1;
+                }
+            }
+        }, |_|{});
+        //let order = get_dfs_preorder(adj);
+        /*
         for (i, &u) in order.iter().enumerate() {
             tin[u] = i;
             for &v in &adj[u] {
@@ -52,6 +64,7 @@ impl LCA {
                 }
             }
         }
+        */
         let d_with_order: Vec<(usize, usize)> = order.iter().map(|&u| (d[u], u)).collect();
         let rmq = RMQ::new(&d_with_order, std::cmp::min);
         LCA { tin, p, rmq }

--- a/src/graphs/lca.rs
+++ b/src/graphs/lca.rs
@@ -43,16 +43,20 @@ impl LCA {
         let mut p = vec![0; n];
         let mut d = vec![0; n];
         let mut order = Vec::with_capacity(n);
-        dfs(adj, |u| {
-            tin[u] = order.len();
-            order.push(u);
-            for &v in &adj[u] {
-                if v != p[u] {
-                    p[v] = u;
-                    d[v] = d[u] + 1;
+        dfs(
+            adj,
+            |u| {
+                tin[u] = order.len();
+                order.push(u);
+                for &v in &adj[u] {
+                    if v != p[u] {
+                        p[v] = u;
+                        d[v] = d[u] + 1;
+                    }
                 }
-            }
-        }, |_|{});
+            },
+            |_| {},
+        );
         //let order = get_dfs_preorder(adj);
         /*
         for (i, &u) in order.iter().enumerate() {

--- a/src/graphs/mod.rs
+++ b/src/graphs/mod.rs
@@ -1,7 +1,7 @@
 //! # Graph Algorithms
 pub mod cent_decomp;
 pub mod count_paths_per_length;
-mod dfs;
+pub mod dfs;
 mod dfs_order;
 pub mod dijk;
 pub mod hld;

--- a/src/graphs/mod.rs
+++ b/src/graphs/mod.rs
@@ -1,6 +1,7 @@
 //! # Graph Algorithms
 pub mod cent_decomp;
 pub mod count_paths_per_length;
+mod dfs;
 mod dfs_order;
 pub mod dijk;
 pub mod hld;


### PR DESCRIPTION
pro: functions `pre` and `post` are called in the order they would be in a normal dfs, so random example of something you could do with this, but not with current pre-post order Vec's: keep track of DFS stack for O(1) offline kth-par

con: you can't modify the actual adjacent list var inside the closure; so this can't be used for HLD

on a side note; using unnecessary space (the Vec which stores pre,post order) kinda bugs me - this is the motivation for doing it instead with closures: also this way with closures is more functional. For the same reason, I think we should switch https://github.com/programming-team-code/programming_team_code_rust/blob/main/src/numbers/primes.rs#L53 to calling closure on each prime factor instead of returning array