### PR TITLE
trie golf/nit

### DIFF
--- a/src/data_structures/trie.rs
+++ b/src/data_structures/trie.rs
@@ -45,7 +45,7 @@ impl Trie {
     pub fn insert(&mut self, s: &[char]) {
         let mut v = 0;
         for &ch in s {
-            let idx = (ch as u8 - FIRST_CHAR as u8) as usize;
+            let idx = ch as usize - FIRST_CHAR as usize;
             if self.t[v].next[idx].is_none() {
                 self.t[v].next[idx] = Some(self.t.len());
                 self.t.push(Node::default());
@@ -63,11 +63,12 @@ impl Trie {
     pub fn find(&self, s: &[char]) -> usize {
         let mut v = 0;
         for &ch in s {
-            let idx = (ch as u8 - FIRST_CHAR as u8) as usize;
-            if self.t[v].next[idx].is_none() {
+            let idx = ch as usize - FIRST_CHAR as usize;
+            if let Some(u) = self.t[v].next[idx] {
+                v = u;
+            } else {
                 return 0;
             }
-            v = self.t[v].next[idx].unwrap();
         }
         self.t[v].cnt_words
     }


### PR DESCRIPTION
also you used `v` for the "current node" and `u` for the "child node", whereas I've been doing it the other way around (like [here](https://github.com/programming-team-code/programming_team_code_rust/blob/main/src/graphs/hld.rs#L57-L59))

Thoughts on standardizing this? BTW KACTL does it [your way](https://github.com/kth-competitive-programming/kactl/blob/main/content/graph/HLD.h#L30)