### PR TITLE
Bin trie nits

### DIFF
--- a/examples/data_structures/binary_trie.rs
+++ b/examples/data_structures/binary_trie.rs
@@ -12,7 +12,7 @@ fn main() {
     for _ in 0..q {
         input! {
             t: u8,
-            x: usize,
+            x: u32,
         }
 
         match t {

--- a/src/data_structures/binary_trie.rs
+++ b/src/data_structures/binary_trie.rs
@@ -1,9 +1,11 @@
 //! # Binary Trie which can be used as a multiset of integers
 
+pub type T = u32;
+
 #[derive(Default)]
 struct Node {
     next: [Option<usize>; 2],
-    sub_sz: isize,
+    sub_sz: i32,
 }
 
 /// # Example
@@ -44,10 +46,10 @@ impl BinaryTrie {
     /// # Complexity
     /// - Time: O(log(max_num))
     /// - Space: O(log(max_num))
-    pub fn update(&mut self, num: usize, delta: isize) {
+    pub fn update(&mut self, num: T, delta: i32) {
         let mut v = 0;
-        for i in (0..usize::BITS).rev() {
-            let bit = (num >> i) & 1;
+        for i in (0..T::BITS).rev() {
+            let bit = ((num >> i) & 1) as usize;
             if self.t[v].next[bit].is_none() {
                 self.t[v].next[bit] = Some(self.t.len());
                 self.t.push(Node::default());
@@ -63,10 +65,10 @@ impl BinaryTrie {
     /// # Complexity
     /// - Time: O(log(max_num))
     /// - Space: O(1)
-    pub fn count(&self, num: usize) -> isize {
+    pub fn count(&self, num: T) -> i32 {
         let mut v = 0;
-        for i in (0..usize::BITS).rev() {
-            let bit = (num >> i) & 1;
+        for i in (0..T::BITS).rev() {
+            let bit = ((num >> i) & 1) as usize;
             if self.t[v].next[bit].is_none() {
                 return 0;
             }
@@ -80,12 +82,12 @@ impl BinaryTrie {
     /// # Complexity
     /// - Time: O(log(max_num))
     /// - Space: O(1)
-    pub fn min_xor(&self, num: usize) -> usize {
+    pub fn min_xor(&self, num: T) -> T {
         assert!(self.t.len() > 1);
         let mut v = 0;
         let mut ans = 0;
-        for i in (0..usize::BITS).rev() {
-            let bit = (num >> i) & 1;
+        for i in (0..T::BITS).rev() {
+            let bit = ((num >> i) & 1) as usize;
             if self.t[v].next[bit].is_some() && self.t[self.t[v].next[bit].unwrap()].sub_sz > 0 {
                 v = self.t[v].next[bit].unwrap();
             } else {

--- a/src/data_structures/binary_trie.rs
+++ b/src/data_structures/binary_trie.rs
@@ -1,5 +1,6 @@
 //! # Binary Trie which can be used as a multiset of integers
 
+/// u32 or u64
 pub type T = u32;
 
 #[derive(Default)]

--- a/src/data_structures/binary_trie.rs
+++ b/src/data_structures/binary_trie.rs
@@ -69,10 +69,11 @@ impl BinaryTrie {
         let mut v = 0;
         for i in (0..T::BITS).rev() {
             let bit = ((num >> i) & 1) as usize;
-            if self.t[v].next[bit].is_none() {
+            if let Some(u) = self.t[v].next[bit] {
+                v = u;
+            } else {
                 return 0;
             }
-            v = self.t[v].next[bit].unwrap();
         }
         self.t[v].sub_sz
     }
@@ -83,7 +84,7 @@ impl BinaryTrie {
     /// - Time: O(log(max_num))
     /// - Space: O(1)
     pub fn min_xor(&self, num: T) -> T {
-        assert!(self.t.len() > 1);
+        assert!(self.t[0].sub_sz > 0);
         let mut v = 0;
         let mut ans = 0;
         for i in (0..T::BITS).rev() {

--- a/src/data_structures/trie.rs
+++ b/src/data_structures/trie.rs
@@ -6,7 +6,7 @@ const FIRST_CHAR: usize = 'A' as usize;
 #[derive(Default)]
 struct Node {
     next: [Option<usize>; ALPHABET_SIZE],
-    cnt_words: usize,
+    cnt_words: i32,
 }
 
 /// # Example
@@ -60,7 +60,7 @@ impl Trie {
     /// # Complexity
     /// - Time: O(|s|)
     /// - Space: O(1)
-    pub fn find(&self, s: &[char]) -> usize {
+    pub fn find(&self, s: &[char]) -> i32 {
         let mut v = 0;
         for &ch in s {
             let idx = ch as usize - FIRST_CHAR;


### PR DESCRIPTION
a couple changes:

- change type of `sub_sz` away from isize/usize
- added `pub type T = u32;` so now if you want only 32 bits, it should be twice as fast & half the memory as previously with usize
- `if let Some() = ..` syntax similar to https://github.com/programming-team-code/programming_team_code_rust/pull/84