### PR TITLE
standardize how we templatize

### DIFF
--- a/examples/data_structures/rmq.rs
+++ b/examples/data_structures/rmq.rs
@@ -10,7 +10,7 @@ fn main() {
         a: [usize; n],
     }
 
-    let rmq = RMQ::new(&a, std::cmp::min);
+    let rmq = RMQ::new(&a, |&x, &y| std::cmp::min(x, y));
     for _ in 0..q {
         input! {
             le: usize,

--- a/examples/data_structures/seg_tree_aizu.rs
+++ b/examples/data_structures/seg_tree_aizu.rs
@@ -8,7 +8,7 @@ fn main() {
         n: usize,
         q: usize,
     }
-    let mut st = SegTree::<usize>::new(n, |x, y| x + y, 0);
+    let mut st = SegTree::new(n, |x, y| x + y, 0);
     for _ in 0..q {
         input! {
             t: u8,

--- a/examples/data_structures/seg_tree_yosupo.rs
+++ b/examples/data_structures/seg_tree_yosupo.rs
@@ -21,7 +21,7 @@ fn main() {
         })
         .collect::<Vec<(u64, u64)>>();
 
-    let mut seg_tree = SegTree::<(u64, u64)>::build_on_array(
+    let mut seg_tree = SegTree::build_on_array(
         &a,
         |x, y| (x.0 * y.0 % MOD, (y.0 * x.1 + y.1) % MOD),
         (1, 0),

--- a/examples/graphs/hld_path_composite_yosupo.rs
+++ b/examples/graphs/hld_path_composite_yosupo.rs
@@ -39,12 +39,12 @@ fn main() {
         input_a[hld.tin[i]] = elem;
     }
 
-    let mut st_forwards = SegTree::<(u64, u64)>::build_on_array(
+    let mut st_forwards = SegTree::build_on_array(
         &input_a,
         |x, y| (x.0 * y.0 % MOD, (y.0 * x.1 + y.1) % MOD),
         (1, 0),
     );
-    let mut st_backwards = SegTree::<(u64, u64)>::build_on_array(
+    let mut st_backwards = SegTree::build_on_array(
         &input_a,
         |x, y| (x.0 * y.0 % MOD, (x.0 * y.1 + x.1) % MOD),
         (1, 0),

--- a/examples/monotonic/mono_st.rs
+++ b/examples/monotonic/mono_st.rs
@@ -14,7 +14,7 @@ fn main() {
 
     let rmq = RMQ::new(
         &(0..n).map(|i| (i, i)).collect::<Vec<_>>(),
-        |(min_i1, max_i1), (min_i2, max_i2)| {
+        |&(min_i1, max_i1), &(min_i2, max_i2)| {
             let min_idx = if a[min_i1] < a[min_i2] {
                 min_i1
             } else {

--- a/examples/strings/suf_ary_find_substr_many_aizu.rs
+++ b/examples/strings/suf_ary_find_substr_many_aizu.rs
@@ -26,7 +26,7 @@ fn main() {
     }
 
     let suf_ary = SufAry::new(&s, 255);
-    let rmq = RMQ::new(&suf_ary.sa, std::cmp::min);
+    let rmq = RMQ::new(&suf_ary.sa, |&x, &y| std::cmp::min(x, y));
 
     for i in 0..num_queries_find_substr {
         let idx = rmq.query(suf_ary.find_substr(length[i]..length[i + 1]));

--- a/src/data_structures/rmq.rs
+++ b/src/data_structures/rmq.rs
@@ -5,12 +5,12 @@
 /// use programming_team_code_rust::data_structures::rmq::RMQ;
 ///
 /// let a = [1, 3, 2, 4, 5];
-/// let rmq1 = RMQ::new(&a, std::cmp::min);
+/// let rmq1 = RMQ::new(&a, |&x, &y| std::cmp::min(x, y));
 /// assert_eq!(rmq1.query(0..5), 1);
 /// assert_eq!(rmq1.query(1..4), 2);
 ///
 /// let outside_var = 5;
-/// let rmq2 = RMQ::new(&a, |x, y| if x + outside_var < y + outside_var { x } else { y });
+/// let rmq2 = RMQ::new(&a, |&x, &y| if x + outside_var < y + outside_var { x } else { y });
 /// assert_eq!(rmq2.query(0..5), 1);
 /// assert_eq!(rmq2.query(1..4), 2);
 /// ```

--- a/src/data_structures/rmq.rs
+++ b/src/data_structures/rmq.rs
@@ -19,19 +19,19 @@ pub struct RMQ<T, F> {
     op: F,
 }
 
-impl<T: Copy, F: Fn(T, T) -> T> RMQ<T, F> {
+impl<T: Clone, F: Fn(&T, &T) -> T> RMQ<T, F> {
     /// Create a new RMQ instance
     ///
     /// # Complexity (n = a.len())
     /// - Time: O(n log n)
     /// - Space: O(n log n)
     pub fn new(a: &[T], op: F) -> Self {
-        let mut t = vec![a.to_owned(); 1];
+        let mut t = vec![a.to_vec(); 1];
         let mut i = 0;
         while (2 << i) <= a.len() {
             t.push(
                 (0..t[i].len() - (1 << i))
-                    .map(|j| op(t[i][j], t[i][j + (1 << i)]))
+                    .map(|j| op(&t[i][j], &t[i][j + (1 << i)]))
                     .collect(),
             );
             i += 1;
@@ -46,6 +46,6 @@ impl<T: Copy, F: Fn(T, T) -> T> RMQ<T, F> {
     /// - Space: O(1)
     pub fn query(&self, range: std::ops::Range<usize>) -> T {
         let lg = range.len().ilog2() as usize;
-        (self.op)(self.t[lg][range.start], self.t[lg][range.end - (1 << lg)])
+        (self.op)(&self.t[lg][range.start], &self.t[lg][range.end - (1 << lg)])
     }
 }

--- a/src/data_structures/seg_tree.rs
+++ b/src/data_structures/seg_tree.rs
@@ -18,7 +18,7 @@ pub struct SegTree<T, F> {
     tree: Vec<T>,
 }
 
-impl<T: Clone, F: FnMut(&T, &T) -> T> SegTree<T, F> {
+impl<T: Clone, F: Fn(&T, &T) -> T> SegTree<T, F> {
     /// Creates a new segment tree with n elements
     ///
     /// # Complexity
@@ -38,7 +38,7 @@ impl<T: Clone, F: FnMut(&T, &T) -> T> SegTree<T, F> {
     /// # Complexity
     /// - Time: O(n)
     /// - Space: O(n)
-    pub fn build_on_array(a: &[T], mut op: F, unit: T) -> Self {
+    pub fn build_on_array(a: &[T], op: F, unit: T) -> Self {
         let n = a.len();
         let mut tree = vec![unit.clone(); n];
         tree.extend(a.to_vec());
@@ -67,7 +67,7 @@ impl<T: Clone, F: FnMut(&T, &T) -> T> SegTree<T, F> {
     /// # Complexity
     /// - Time: O(log n)
     /// - Space: O(1)
-    pub fn query(&mut self, range: std::ops::Range<usize>) -> T {
+    pub fn query(&self, range: std::ops::Range<usize>) -> T {
         let (mut vl, mut vr, mut le, mut ri) = (
             self.unit.clone(),
             self.unit.clone(),

--- a/src/data_structures/seg_tree.rs
+++ b/src/data_structures/seg_tree.rs
@@ -4,27 +4,27 @@
 /// ```
 /// use programming_team_code_rust::data_structures::seg_tree::SegTree;
 ///
-/// let mut st = SegTree::<usize>::new(3, |&x, &y| x + y, 0);
+/// let mut st = SegTree::new(3, |&x, &y| x + y, 0);
 /// st.set(1, 2);
 /// st.set(2, 3);
 /// assert_eq!(st.query(0..3), 5);
 /// ```
-pub struct SegTree<T> {
+pub struct SegTree<T, F> {
     n: usize,
     /// associative operation
-    pub op: fn(&T, &T) -> T,
+    pub op: F,
     /// identity element
     pub unit: T,
     tree: Vec<T>,
 }
 
-impl<T: Clone> SegTree<T> {
+impl<T: Clone, F: Fn(&T, &T) -> T> SegTree<T, F> {
     /// Creates a new segment tree with n elements
     ///
     /// # Complexity
     /// - Time: O(n)
     /// - Space: O(n)
-    pub fn new(n: usize, op: fn(&T, &T) -> T, unit: T) -> Self {
+    pub fn new(n: usize, op: F, unit: T) -> Self {
         Self {
             n,
             op,
@@ -38,7 +38,7 @@ impl<T: Clone> SegTree<T> {
     /// # Complexity
     /// - Time: O(n)
     /// - Space: O(n)
-    pub fn build_on_array(a: &[T], op: fn(&T, &T) -> T, unit: T) -> Self {
+    pub fn build_on_array(a: &[T], op: F, unit: T) -> Self {
         let n = a.len();
         let mut tree = vec![unit.clone(); n];
         tree.extend(a.to_vec());

--- a/src/data_structures/seg_tree.rs
+++ b/src/data_structures/seg_tree.rs
@@ -18,7 +18,7 @@ pub struct SegTree<T, F> {
     tree: Vec<T>,
 }
 
-impl<T: Clone, F: Fn(&T, &T) -> T> SegTree<T, F> {
+impl<T: Clone, F: FnMut(&T, &T) -> T> SegTree<T, F> {
     /// Creates a new segment tree with n elements
     ///
     /// # Complexity
@@ -38,7 +38,7 @@ impl<T: Clone, F: Fn(&T, &T) -> T> SegTree<T, F> {
     /// # Complexity
     /// - Time: O(n)
     /// - Space: O(n)
-    pub fn build_on_array(a: &[T], op: F, unit: T) -> Self {
+    pub fn build_on_array(a: &[T], mut op: F, unit: T) -> Self {
         let n = a.len();
         let mut tree = vec![unit.clone(); n];
         tree.extend(a.to_vec());
@@ -67,7 +67,7 @@ impl<T: Clone, F: Fn(&T, &T) -> T> SegTree<T, F> {
     /// # Complexity
     /// - Time: O(log n)
     /// - Space: O(1)
-    pub fn query(&self, range: std::ops::Range<usize>) -> T {
+    pub fn query(&mut self, range: std::ops::Range<usize>) -> T {
         let (mut vl, mut vr, mut le, mut ri) = (
             self.unit.clone(),
             self.unit.clone(),

--- a/src/graphs/lca.rs
+++ b/src/graphs/lca.rs
@@ -3,7 +3,7 @@
 use crate::data_structures::rmq::RMQ;
 use crate::graphs::dfs_order::get_dfs_preorder;
 
-type OpType = fn((usize, usize), (usize, usize)) -> (usize, usize);
+type OpType = fn(&(usize, usize), &(usize, usize)) -> (usize, usize);
 
 /// # Example
 /// ```
@@ -53,11 +53,8 @@ impl LCA {
             tin,
             p,
             rmq: RMQ::new(
-                &order
-                    .iter()
-                    .map(|&u| (d[u], u))
-                    .collect::<Vec<(usize, usize)>>(),
-                std::cmp::min,
+                &order.iter().map(|&u| (d[u], u)).collect::<Vec<_>>(),
+                |&x, &y| std::cmp::min(x, y),
             ),
         }
     }

--- a/src/helpers/compress.rs
+++ b/src/helpers/compress.rs
@@ -19,7 +19,7 @@
 /// - Space: O(n)
 pub fn compress<T: Ord>(a: &[T]) -> (Vec<usize>, usize) {
     let n = a.len();
-    let mut idx = (0..n).collect::<Vec<usize>>();
+    let mut idx = (0..n).collect::<Vec<_>>();
     idx.sort_by_key(|&i| &a[i]);
     let mut compressed = vec![0; n];
     let mut max_val = 0;

--- a/src/strings/suf_ary.rs
+++ b/src/strings/suf_ary.rs
@@ -68,7 +68,7 @@ pub struct SufAry {
     pub sa_inv: Vec<usize>,
     /// longest common prefix array
     pub lcp: Vec<usize>,
-    rmq: RMQ<usize, fn(usize, usize) -> usize>,
+    rmq: RMQ<usize, fn(&usize, &usize) -> usize>,
 }
 
 impl SufAry {
@@ -91,7 +91,7 @@ impl SufAry {
             n: sa.len(),
             s: s.to_vec(),
             sa_inv,
-            rmq: RMQ::new(&lcp, std::cmp::min),
+            rmq: RMQ::new(&lcp, |&x, &y| std::cmp::min(x, y)),
             lcp,
             sa,
         }

--- a/src/strings/suf_ary.rs
+++ b/src/strings/suf_ary.rs
@@ -33,7 +33,7 @@ use ac_library::string::{lcp_array_arbitrary, suffix_array_manual};
 /// //   ||
 /// // 2 nana   5
 ///
-/// let suf_ary1 = SufAry::new(&s.chars().map(|c| c as usize).collect::<Vec<usize>>(), 255);
+/// let suf_ary1 = SufAry::new(&s.chars().map(|c| c as usize).collect::<Vec<_>>(), 255);
 /// let n = suf_ary1.sa.len();
 /// assert_eq!(suf_ary1.sa, [5, 3, 1, 0, 4, 2]);
 /// assert_eq!(suf_ary1.sa_inv, [3, 2, 5, 1, 4, 0]);
@@ -52,7 +52,7 @@ use ac_library::string::{lcp_array_arbitrary, suffix_array_manual};
 /// assert_eq!(suf_ary1.cmp_substrs(1..4, 3..6), Ordering::Equal);
 /// assert!(std::panic::catch_unwind(|| suf_ary1.cmp_substrs(3..4, n..n)).is_err());
 ///
-/// assert_eq!(suf_ary1.find_str(&"ana".chars().map(|c| c as usize).collect::<Vec<usize>>()), 1..3);
+/// assert_eq!(suf_ary1.find_str(&"ana".chars().map(|c| c as usize).collect::<Vec<_>>()), 1..3);
 /// assert_eq!(suf_ary1.find_str(&[]), 0..n);
 ///
 /// assert_eq!(suf_ary1.find_substr(1..4), 1..3);
@@ -79,7 +79,7 @@ impl SufAry {
     /// - Space: O(n)
     pub fn new(s: &[usize], max_val: usize) -> Self {
         let sa = suffix_array_manual(
-            &s.iter().map(|&x| x as i32).collect::<Vec<i32>>(),
+            &s.iter().map(|&x| x as i32).collect::<Vec<_>>(),
             max_val as i32,
         );
         let lcp = lcp_array_arbitrary(s, &sa);


### PR DESCRIPTION
whenever you need to templatize a type, and and op/compare (examples: RMQ, seg tree, mono st) let's standardize it like:

`<T: Clone, F: Fn(&T, &T) -> T>`